### PR TITLE
suggested improvements to make copy friendly runnable codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,16 @@ The following instructions can be used if you are using SDKMAN!
 2. Install Java 8 by typing `sdk install java 8.0.362-librca`
 3. Install Java 17 by typing `sdk install java 22.3.r17-nik`
 
-Check that you can use Java 8
+Check that you can use Java 8 by running the following in a terminal:
 
 ```shell
-$ sdk use java 8.0.362-librca
-$ java -version
+sdk use java 8.0.362-librca
+java -version
+```
+
+You should see the following output:
+
+```
 openjdk version "1.8.0_362"
 OpenJDK Runtime Environment (build 1.8.0_362-b09)
 OpenJDK 64-Bit Server VM (build 25.362-b09, mixed mode)
@@ -29,8 +34,13 @@ OpenJDK 64-Bit Server VM (build 25.362-b09, mixed mode)
 Check that you can use Java 17
 
 ```shell
-$ sdk use java 22.3.r17-nik
-$ java -version
+sdk use java 22.3.r17-nik
+java -version
+```
+
+You should see the following output:
+
+```
 openjdk version "17.0.5" 2022-10-18 LTS
 OpenJDK Runtime Environment GraalVM 22.3.0 (build 17.0.5+8-LTS)
 OpenJDK 64-Bit Server VM GraalVM 22.3.0 (build 17.0.5+8-LTS, mixed mode, sharing)
@@ -39,7 +49,12 @@ OpenJDK 64-Bit Server VM GraalVM 22.3.0 (build 17.0.5+8-LTS, mixed mode, sharing
 Check that you can use GraalVM
 
 ```shell
-$ native-image --version
+native-image --version
+```
+
+You should see the following output:
+
+```
 GraalVM 22.3.0 Java 17 CE (Java Version 17.0.5+8-LTS)
 ```
 
@@ -49,20 +64,35 @@ GraalVM 22.3.0 Java 17 CE (Java Version 17.0.5+8-LTS)
 The following instructions can be used if you are using CHOCOLATEY!
 
 1. Install CHOCOLATEY! for your system by following instructions at https://community.chocolatey.org/
-2. Install Java 8 by typing `PS C:\> choco install liberica8jdk` (in PowerShell as Administrator)
-3. Install Java 17 by typing `PS C:\> choco install graalvm-java17` (in PowerShell as Administrator)
+2. Install Java 8 by running the following in a PowerShell as Administrator:
+
+   ```shell
+   choco install liberica8jdk
+   ```
+
+3. Install Java 17 by running the following in a PowerShell as Administrator:
+
+   ```shell
+   choco install graalvm-java17
+   ```
 
 Check that you can use Java 8 and GraalVM 17
 
 1. Open `System Properties`
 2. Click `Environment Variables...` and change the `PATH` and `JAVA_HOME` System Variables to use the right JDK/GraalVM paths
 3. Open a new PowerShell window and check the Java version
-```shell
-PS C:\> java -version
-openjdk version "17.0.6" 2023-01-17
-OpenJDK Runtime Environment GraalVM CE 22.3.1 (build 17.0.6+10-jvmci-22.3-b13)
-OpenJDK 64-Bit Server VM GraalVM CE 22.3.1 (build 17.0.6+10-jvmci-22.3-b13, mixed mode, sharing)
-```
+
+   ```shell
+   java -version
+   ```
+
+   You should see the following output:
+
+   ```
+   openjdk version "17.0.6" 2023-01-17
+   OpenJDK Runtime Environment GraalVM CE 22.3.1 (build 17.0.6+10-jvmci-22.3-b13)
+   OpenJDK 64-Bit Server VM GraalVM CE 22.3.1 (build 17.0.6+10-jvmci-22.3-b13, mixed mode, sharing)
+   ```
 
 
 
@@ -73,12 +103,24 @@ As long as you have Java 17 and the `native-image` tool install, you should be f
 Please check your installation by checking the output of `java -version` and `native-image --version`:
 
 ```shell
-$ java -version
+java -version
+```
+
+You should see the following output:
+
+```
 openjdk version "17.0.5" 2022-10-18 LTS
 OpenJDK Runtime Environment GraalVM 22.3.0 (build 17.0.5+8-LTS)
 OpenJDK 64-Bit Server VM GraalVM 22.3.0 (build 17.0.5+8-LTS, mixed mode, sharing)
+```
 
-$ native-image --version
+```shell
+native-image --version
+```
+
+You should see the following output:
+
+```
 GraalVM 22.3.0 Java 17 CE (Java Version 17.0.5+8-LTS)
 ```
 
@@ -91,7 +133,7 @@ command not found: native-image
 This might not be a big problem, it might only mean that your GraalVM installation does not have `native-image` pre-installed. Try to install it with the GraalVM Updater:
 
 ```shell
-$ gu install native-image
+gu install native-image
 ```
 
 > **NOTE**: On Windows, GraalVM installation contains the `gu.cmd` command. Depending on the terminal you use, it can be executed as just `gu` or `gu.cmd`.
@@ -99,7 +141,7 @@ $ gu install native-image
 And check the version again:
 
 ```shell
-$ native-image --version
+native-image --version
 ```
 
 
@@ -112,19 +154,19 @@ To check that Maven works run the following command from this directory.
 On Linux/Mac
 
 ```shell
-$ ./mvnw --version
+./mvnw --version
 ```
 
 On Windows
 
 ```shell
-$ mvnw.cmd --version
+mvnw.cmd --version
 ```
 
 If you want to ensure your local Maven cache has most of the files we'll need, you can build the pom files in this directory:
 
 ```shell
-$ ./mvnw package
+./mvnw package
 ```
 
 You should see a "success" message after these command:
@@ -147,19 +189,19 @@ Please install Docker from https://www.docker.com or using your favorite open so
 To check docker is running, you can run:
 
 ```shell
-$ docker run --rm hello-world
+docker run --rm hello-world
 ```
 
 To check docker compose is working, run the following from this directory:
 
 ```shell
-$ docker compose -f docker-compose-hello.yml up
+docker compose -f docker-compose-hello.yml up
 ```
 
 Once you see the "hello world" output, you can destroy the containers using:
 
 ```shell
-$ docker compose -f docker-compose-hello.yml down
+docker compose -f docker-compose-hello.yml down
 ```
 
 TIP: Depending on your installation, you might need to use the command `docker-compose` rather than `docker compose`.
@@ -167,7 +209,7 @@ TIP: Depending on your installation, you might need to use the command `docker-c
 If the hello world example works, then you can try starting the full docker compose configuration that we'll be using:
 
 ```shell
-$ docker compose up
+docker compose up
 ```
 
 NOTE: it will take some time to initially start the containers
@@ -180,7 +222,7 @@ http://localhost:3000 (Grafana)
 If everything works you can hit `ctrl-c` to stop docker compose and you can destroy the containers using:
 
 ```shell
-$ docker compose down
+docker compose down
 ```
 
 


### PR DESCRIPTION
Github markdown rendering add copy buttons to the code blocks.

To make it easier for students to execute the specific commands outlined in the installation procedures, consider separating the commands to execute (that they can copy, and run in a terminal) from the output.